### PR TITLE
Add default values to Sass variables. Add contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Thanks you for considering a contribution to this project!
+
+## Setting up the project
+
+After installing Ruby, run the following command to install dependencies:
+
+```
+bundle install
+```
+
+## Testing
+
+Run tests with:
+
+```
+bundle exec rake spec
+```

--- a/app/assets/stylesheets/active_versioning/workflow.scss
+++ b/app/assets/stylesheets/active_versioning/workflow.scss
@@ -5,6 +5,12 @@
  * Dependent upon ActiveMaterial.
  */
 
+// These variables will be overriden by ActiveMaterial if it exists
+$theme-divider: #efefef !default;
+$theme-primary: #009688 !default;
+$theme-accent: #cddc39 !default;
+$theme-error: #f44336 !default;
+
 .column {
   float: left;
 }


### PR DESCRIPTION
In an upstream branch of ActiveMaterial, I namespace all variables with `am-`. Currently, this will break this repository. This PR adds default values to a few Sass variables to eliminate the possibility of an exception being raised.

Also, I added a CONTRIBUTING.md with information on setup and testing.
